### PR TITLE
add bucket to fuse by default

### DIFF
--- a/notebook/worker-template.yaml
+++ b/notebook/worker-template.yaml
@@ -11,6 +11,9 @@ spec:
       - 6GB
       - --death-timeout
       - '60'
+    env:
+      - name: GCSFUSE_BUCKET
+        value: rhg-data
     image: rhodium/worker:2018-04-04
     name: dask-worker
     securityContext:


### PR DESCRIPTION
this will get mounted on `/gcs` by https://github.com/RhodiumGroup/docker_images/blob/master/worker/prepare.sh