### PR TITLE
fix worker-template.yaml name in prepare.sh

### DIFF
--- a/notebook/prepare.sh
+++ b/notebook/prepare.sh
@@ -39,7 +39,7 @@ else
         /usr/bin/gcsfuse --key-file=$SA_FILE $GCSFUSE_BUCKET /gcs
     fi
 
-    if [ -f /home/jovyan/worker-template.yml ]; then
+    if [ -f /home/jovyan/worker-template.yaml ]; then
         echo "appending service-account-credentials to worker-template"
         python /home/jovyan/add_service_creds.py
     fi


### PR DESCRIPTION
The name of the file is worker-template.yaml, not worker-template.yml. We use yaml and yml inconsistently throughout this repo - we should probably pick one and stick to it. Lol... took me forever to figure out what was going wrong here!