### PR TITLE
implement flexible bucket mounting system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ services:
   - docker
 env:
   global:
-    - TAG=2018-07-28.03
+    - TAG=2018-07-28.04
   matrix:
     - IMAGE_NAME=notebook
     - IMAGE_NAME=worker

--- a/jupyter-config.yml
+++ b/jupyter-config.yml
@@ -2,7 +2,7 @@ jupyterhub:
   singleuser:
     image:
       name: rhodium/notebook
-      tag: 2018-07-28.03
+      tag: 2018-07-28.04
     storage:
       capacity: 10Gi
     dynamic:

--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -132,8 +132,8 @@ RUN mkdir /pre-home && chown -R $NB_USER /pre-home
 COPY worker-template.yml /pre-home
 COPY add_service_creds.py /pre-home
 
-COPY config.yaml /pre-home
-COPY worker-template.yaml /pre-home
+COPY config.yml /pre-home
+COPY worker-template.yml /pre-home
 
 
 RUN export GCSFUSE_REPO=gcsfuse-xenial \

--- a/notebook/add_service_creds.py
+++ b/notebook/add_service_creds.py
@@ -1,4 +1,4 @@
-import json, yaml
+import json, yaml, os, glob
 
 
 def add_service_creds():
@@ -11,12 +11,16 @@ def add_service_creds():
             print('token already appended')
             return
 
-    with open('/home/jovyan/service-account-credentials.json', 'r') as f:
-        print('loading service account creds')
-        TOKEN_STRING = json.dumps(json.load(f))
+    creds = {}
+
+    for f in glob.glob('/home/jovyan/service-account-credentials/*.json'):
+        bucket = os.path.splitext(os.path.basename(f))[0]
+
+        with open(f, 'r') as f:
+            creds[bucket] = json.load(f)
 
     WORKER_TEMPLATE['spec']['containers'][0]['env'].append(
-        {'name': 'GCSFUSE_TOKEN', 'value': TOKEN_STRING})
+        {'name': 'GCSFUSE_TOKENS', 'value': json.dumps(creds)})
 
     with open('/home/jovyan/worker-template.yml', 'w') as f:
         f.write(yaml.dump(WORKER_TEMPLATE))

--- a/notebook/worker-template.yml
+++ b/notebook/worker-template.yml
@@ -14,7 +14,7 @@ spec:
     env:
       - name: GCSFUSE_BUCKET
         value: rhg-data
-    image: rhodium/worker:2018-07-28.03
+    image: rhodium/worker:2018-07-28.04
     name: dask-worker
     securityContext:
       capabilities:

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -81,6 +81,7 @@ RUN chmod +x cloud_sql_proxy
 
 USER root
 COPY prepare.sh /usr/bin/prepare.sh
+COPY add_service_creds.py /usr/bin/add_service_creds.py
 RUN chmod +x /usr/bin/prepare.sh
 RUN mkdir /opt/app
 RUN mkdir /gcs

--- a/worker/add_service_creds.py
+++ b/worker/add_service_creds.py
@@ -1,0 +1,17 @@
+import json, os
+
+
+def create_service_cred_files():
+
+    with open("/opt/gcsfuse_token_strings.json", 'r') as f:
+        creds = json.load(f)
+
+    os.makedirs('/opt/gcsfuse_tokens/')
+
+    for k, v in creds.items():
+        with open('/opt/gcsfuse_tokens/{}.json'.format(k), 'w+') as f:
+            f.write(v)
+
+
+if __name__ == '__main__':
+    create_service_cred_files()

--- a/worker/prepare.sh
+++ b/worker/prepare.sh
@@ -11,7 +11,7 @@ fi
 
 if [[ "$EXTRA_CONDA_PACKAGES" ]]; then
     echo "EXTRA_CONDA_PACKAGES environment variable found.  Installing."
-    /opt/conda/bin/conda install $EXTRA_CONDA_PACKAGES
+    /opt/conda/bin/conda install --yes $EXTRA_CONDA_PACKAGES
 fi
 
 if [[ "$EXTRA_PIP_PACKAGES" ]]; then
@@ -19,15 +19,20 @@ if [[ "$EXTRA_PIP_PACKAGES" ]]; then
     /opt/conda/bin/pip install $EXTRA_PIP_PACKAGES
 fi
 
-if [[ "$GCSFUSE_TOKEN" ]]; then
-    echo "$GCSFUSE_TOKEN" > /opt/gcsfuse_token.json
-    export GOOGLE_APPLICATION_CREDENTIALS="/opt/gcsfuse_token.json"
-fi
+if [[ "$GCSFUSE_TOKENS" ]]; then
+    echo "$GCSFUSE_TOKEN" > /opt/gcsfuse_token_strings.json
+    python /usr/bin/add_service_creds.py
 
-if [[ "$GCSFUSE_BUCKET" ]]; then
-    echo "Mounting $GCSFUSE_BUCKET to /gcs"
-    /usr/bin/gcsfuse --key-file /opt/gcsfuse_token.json $GCSFUSE_BUCKET /gcs
+    for f in /opt/gcsfuse_tokens/*.json;
+    do
+        bucket=$(basename ${f/.json/});
+        if ! grep -q "/gcs/${bucket}"/proc/mounts; then
+            echo "Mounting $bucket to /gcs/$bucket";
+            mkdir -p /gcs/$bucket;
+            /usr/bin/gcsfuse --key-file=$f$bucket /gcs/$bucket;
+        fi;
+    done
+    fi
 
-fi
 # Run extra commands
 $@

--- a/worker/prepare.sh
+++ b/worker/prepare.sh
@@ -20,7 +20,7 @@ if [[ "$EXTRA_PIP_PACKAGES" ]]; then
 fi
 
 if [[ "$GCSFUSE_TOKENS" ]]; then
-    echo "$GCSFUSE_TOKEN" > /opt/gcsfuse_token_strings.json
+    echo "$GCSFUSE_TOKENS" > /opt/gcsfuse_token_strings.json
     python /usr/bin/add_service_creds.py
 
     for f in /opt/gcsfuse_tokens/*.json;


### PR DESCRIPTION
if this works, closes #19 

Before deploying, needs a thorough test on test-hub, involving:
* testing with multiple account creds (e.g. impactlab-data and rhg-data) in `~/service-account-credentials/[bucket-name].json`
* ensuring the buckets mount on the notebook
* ensuring the buckets mount on the worker
* testing local and distributed netCDF reads from `/gcs/[bucket]/`

Also, this will break all code pointing to data on `/gcs/`. significant warning should be given to the team before deploying.