### PR TITLE
Install EXTRA_PACKAGES to worker env

### DIFF
--- a/worker/prepare.sh
+++ b/worker/prepare.sh
@@ -11,12 +11,12 @@ fi
 
 if [[ "$EXTRA_CONDA_PACKAGES" ]]; then
     echo "EXTRA_CONDA_PACKAGES environment variable found.  Installing."
-    /opt/conda/bin/conda install --yes $EXTRA_CONDA_PACKAGES
+    /opt/conda/envs/worker/bin/conda install --yes $EXTRA_CONDA_PACKAGES
 fi
 
 if [[ "$EXTRA_PIP_PACKAGES" ]]; then
     echo "EXTRA_PIP_PACKAGES environment variable found.  Installing".
-    /opt/conda/bin/pip install $EXTRA_PIP_PACKAGES
+    /opt/conda/envs/worker/bin/pip install $EXTRA_PIP_PACKAGES
 fi
 
 if [[ "$GCSFUSE_TOKENS" ]]; then


### PR DESCRIPTION
## Workflow

* [x] Closes issue #43 
* [ ] Notebook:worker pairing builds & passes local build, visual inspection & client.map tests
* [x] Passes travis tests
* [ ] Image deployed on `dev` branch (see [notebook](https://hub.docker.com/r/rhodium/notebook/tags/) and [worker](https://hub.docker.com/r/rhodium/worker/tags/) dev tags)
* [ ] Worker passes manual deployment test on compute.rhg
* [ ] Notebook+worker passes test-hub deployment
* [ ] Updates integrated into downstream images

## Summary

Currently `EXTRA_CONDA_PACKAGES` and `EXTRA_PIP_PACKAGES` arguments get installed to the root conda env. Moving them to `worker` on the worker images.

### TODO

* We should add something about extra_pip_packages to the standard test suite
* This is specifically affecting @bolliger32 so we should test this against the ClimateImpactLab/bolliger32-clawpack-image build