### PR TITLE
copy service account creds to /opt/gcsfuse_tokens to mirror worker

### DIFF
--- a/notebook/prepare.sh
+++ b/notebook/prepare.sh
@@ -32,6 +32,11 @@ if [[ -e "/home/jovyan/conda_environment.yml" ]]; then
     /opt/conda/bin/conda env create -f /home/jovyan/conda_environment.yml;
 fi
 
+# mirror directory used on workers
+mkdir -p /opt/gcsfuse_tokens/
+mkdir -p /home/jovyan/service-account-credentials/
+cp /home/jovyan/service-account-credentials/*.json /opt/gcsfuse_tokens/
+
 for f in /home/jovyan/service-account-credentials/*.json;
 do
     bucket=$(basename ${f/.json/});

--- a/notebook/prepare.sh
+++ b/notebook/prepare.sh
@@ -33,9 +33,9 @@ if [[ -e "/home/jovyan/conda_environment.yml" ]]; then
 fi
 
 # mirror directory used on workers
-mkdir -p /opt/gcsfuse_tokens/
+sudo mkdir -p /opt/gcsfuse_tokens/
 mkdir -p /home/jovyan/service-account-credentials/
-cp /home/jovyan/service-account-credentials/*.json /opt/gcsfuse_tokens/
+sudo cp /home/jovyan/service-account-credentials/*.json /opt/gcsfuse_tokens/
 
 for f in /home/jovyan/service-account-credentials/*.json;
 do


### PR DESCRIPTION
## Workflow

* [x] Closes issue #38 
* [ ] Notebook:worker pairing builds & passes local build, visual inspection & client.map tests
* [ ] Passes travis tests
* [ ] Image deployed on `dev` branch (see [notebook](https://hub.docker.com/r/rhodium/notebook/tags/) and [worker](https://hub.docker.com/r/rhodium/worker/tags/) dev tags)
* [ ] Worker passes manual deployment test on compute.rhg
* [ ] Notebook+worker passes test-hub deployment
* [ ] Updates integrated into downstream images

## Summary

Add `~/service-account-credentials/*.json` to `/opt/gcsfuse_tokens` to mirror worker setup and make zarr easier to use. Better approaches are suggested in #42 but this'll do for now.

### TODO

* Test to see if we can lump this in with the #43 pull