### PR TITLE
manually install pip 18.0

### DIFF
--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -76,6 +76,7 @@ RUN conda install --yes -c conda-forge \
     pip=18.0 \
     python-blosc=1.4.4 \
     python-snappy=0.5.3 \
+    pyyaml=3.13 \
     rasterio=0.36.0 \
     scikit-image=0.14.0 \
     scikit-learn=0.19.1 \
@@ -133,7 +134,6 @@ RUN pip install \
   pytest-cov==2.5.1 \
   pytest-runner==4.2 \
   pytest==3.6.2 \
-  PyYAML==3.12 \
   Sphinx==1.7.5 \
   tox==3.1.1 \
   wget==3.2 \

--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -73,6 +73,7 @@ RUN conda install --yes -c conda-forge \
     numcodecs=0.5.5 \
     numpy=1.14.2 \
     pandas=0.23.2 \
+    pip=18.0 \
     python-blosc=1.4.4 \
     python-snappy=0.5.3 \
     rasterio=0.36.0 \

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -60,6 +60,7 @@ RUN conda create -n worker --yes -c conda-forge \
     numcodecs=0.5.5 \
     numpy=1.14.2 \
     pandas=0.23.2 \
+    pip=18.0 \
     python-blosc=1.4.4 \
     python-snappy=0.5.3 \
     rasterio=0.36.0 \

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -63,6 +63,7 @@ RUN conda create -n worker --yes -c conda-forge \
     pip=18.0 \
     python-blosc=1.4.4 \
     python-snappy=0.5.3 \
+    pyyaml=3.13 \
     rasterio=0.36.0 \
     scikit-image=0.14.0 \
     scikit-learn=0.19.1 \


### PR DESCRIPTION
## Workflow

* [x] Closes issue #52 
* [ ] Notebook:worker pairing builds & passes local build, visual inspection & client.map tests
* [ ] Passes travis tests
* [ ] Image deployed on `dev` branch (see [notebook](https://hub.docker.com/r/rhodium/notebook/tags/) and [worker](https://hub.docker.com/r/rhodium/worker/tags/) dev tags)
* [ ] Worker passes manual deployment test on compute.rhg
* [ ] Notebook+worker passes test-hub deployment
* [ ] Updates integrated into downstream images

## Summary

Install pip==18.0 from conda-forge 

### Features

* Maybe fixes `AttributeError: module 'pip' has no attribute 'main'` for pip commands on notebooks.