### PR TITLE
Fix extra-conda-packages and change default conda channel to conda-forge

### DIFF
--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -194,5 +194,7 @@ RUN pip install \
   climate-toolbox==0.1.4 \
   --no-cache-dir
 
+RUN conda config --add channels conda-forge
+
 ENTRYPOINT ["tini", "--", "/usr/bin/prepare.sh"]
 CMD ["start.sh jupyter lab"]

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -137,4 +137,6 @@ RUN /opt/conda/envs/worker/bin/pip install \
   climate-toolbox==0.1.4 \
   --no-cache-dir
 
+RUN conda config --add channels conda-forge
+
 ENTRYPOINT ["/usr/local/bin/dumb-init", "/usr/bin/prepare.sh"]

--- a/worker/prepare.sh
+++ b/worker/prepare.sh
@@ -4,14 +4,14 @@ set -x
 
 if [[ -e "/opt/app/environment.yml" ]]; then
     echo "environment.yml found. Installing packages"
-    /opt/conda/bin/conda env update -f /opt/app/environment.yml
+    /opt/conda/bin/conda env update -n worker -f /opt/app/environment.yml
 else
     echo "no environment.yml"
 fi
 
 if [[ "$EXTRA_CONDA_PACKAGES" ]]; then
     echo "EXTRA_CONDA_PACKAGES environment variable found.  Installing."
-    /opt/conda/envs/worker/bin/conda install --yes $EXTRA_CONDA_PACKAGES
+    conda install -n worker --yes $EXTRA_CONDA_PACKAGES
 fi
 
 if [[ "$EXTRA_PIP_PACKAGES" ]]; then

--- a/worker/prepare.sh
+++ b/worker/prepare.sh
@@ -11,7 +11,7 @@ fi
 
 if [[ "$EXTRA_CONDA_PACKAGES" ]]; then
     echo "EXTRA_CONDA_PACKAGES environment variable found.  Installing."
-    conda install -n worker --yes $EXTRA_CONDA_PACKAGES
+    /opt/conda/bin/conda install -n worker --yes $EXTRA_CONDA_PACKAGES
 fi
 
 if [[ "$EXTRA_PIP_PACKAGES" ]]; then


### PR DESCRIPTION
## Workflow

* [x] Closes issue #63 and #62 
* [ ] Notebook:worker pairing builds & passes local build, visual inspection & client.map tests
* [x] Passes travis tests
* [ ] Image deployed on `dev` branch (see [notebook](https://hub.docker.com/r/rhodium/notebook/tags/) and [worker](https://hub.docker.com/r/rhodium/worker/tags/) dev tags)
* [ ] Worker passes manual deployment test on compute.rhg
* [ ] Notebook+worker passes test-hub deployment
* [ ] Updates integrated into downstream images

## Summary

See title.

### Features

* EXTRA CONDA PACKAGES flag workers for installing packages on worker
* conda-forge is default channel for conda installations on worker and notebook
