### PR TITLE
build netcdf from source

### DIFF
--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -1,4 +1,4 @@
-FROM climateimpactlab/gfortran-netcdf-notebook:latest
+FROM climateimpactlab/gfortran-netcdf-notebook:v1.0.1
 
 # build conda
 
@@ -47,13 +47,15 @@ RUN conda install --yes -c conda-forge \
     netcdf-fortran=4.4.4 \
     netcdf4=1.3.1 \
     nomkl=2.0 \
+    nose=1.3.7 \
     numba=0.37.0 \
     numcodecs=0.5.5 \
     numpy=1.14.2 \
     pandas=0.23.2 \
+    pip=9.0.3 \
+    pyshp=1.2.12 \
     python-blosc=1.4.4 \
     python-snappy=0.5.3 \
-    pip=9.0.3 \
     PyYAML=3.12 \
     rasterio=0.36.0 \
     scikit-image=0.14.0 \

--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -1,4 +1,4 @@
-FROM climateimpactlab/gfortran-netcdf-notebook:v1.0.2
+FROM climateimpactlab/gfortran-netcdf-notebook:v1.0.3
 
 # build conda
 

--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -1,4 +1,4 @@
-FROM climateimpactlab/gfortran-netcdf-notebook:v1.0.1
+FROM climateimpactlab/gfortran-netcdf-notebook:latest
 
 # build conda
 

--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -1,94 +1,12 @@
-##We build our single-user notebook from the base jupyter notebook image
-FROM jupyter/base-notebook
-
-#install some system level packages
-USER root
-
-RUN apt-get update \
-  && apt-get install -yq --no-install-recommends \
-  build-essential \
-  curl \
-  fonts-dejavu \
-  fuse \
-  gfortran \
-  g++ \
-  git \
-  gnupg \
-  gnupg2 \
-  graphviz \
-  keychain \
-  libcurl4-openssl-dev \
-  libfuse-dev \
-  liblapack-dev \
-  libssl-dev \
-  locate \
-  lsb-release \
-  make \
-  m4 \
-  nano \
-  rsync \
-  tzdata \
-  unzip \
-  vim \
-  zip
-
-# build netcdf with gcc and g-fortran
-
-ENV CC=gcc
-ENV FC=gfortran
-
-# set library location
-ENV PREFIXDIR=/usr/local
-
-## get zlib
-RUN wget https://zlib.net/zlib-1.2.11.tar.gz && tar -xvzf zlib-1.2.11.tar.gz
-RUN cd zlib-1.2.11; \
-    ./configure --prefix=${PREFIXDIR}; \
-    make check; \
-    make install; \
-    rm -rf /zlib-1.2.11.tar.gz /zlib-1.2.11
-
-
-## get hdf5-1.8
-RUN wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8/hdf5-1.8.21/src/hdf5-1.8.21.tar.gz && tar -xvzf hdf5-1.8.21.tar.gz
-RUN cd hdf5-1.8.20; \
-    ./configure --with-zlib=${PREFIXDIR} --prefix=${PREFIXDIR} --enable-hl; \
-    make check; \
-    make install; \
-    rm -rf /hdf5-1.8.21.tar.gz /hdf5-1.8.21
-
-## get hdf5-1.10
-RUN wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.2/src/hdf5-1.10.2.tar.gz && tar -xvzf hdf5-1.10.2.tar.gz
-RUN cd hdf5-1.10.2; \
-    ./configure --with-zlib=${PREFIXDIR} --prefix=${PREFIXDIR} --enable-hl --enable-shared; \
-    make check; \
-    make install; \
-    rm -rf /hdf5-1.10.2.tar.gz /hdf5-1.10.2
-
-## get netcdf-c
-RUN wget https://github.com/Unidata/netcdf-c/archive/v4.6.1.tar.gz && tar -xvzf v4.6.1.tar.gz
-ENV LD_LIBRARY_PATH=${PREFIXDIR}/lib
-RUN cd netcdf-c-4.6.1; \
-    CPPFLAGS=-I${PREFIXDIR}/include LDFLAGS=-L${PREFIXDIR}/lib ./configure --prefix=${PREFIXDIR} --enable-netcdf-4 --enable-shared --enable-dap; \
-    make check; \
-    make install; \
-    rm -rf /v4.6.1.tar.gz /netcdf-c-4.6.1
-
-## get netcdf-fortran
-RUN wget https://github.com/Unidata/netcdf-fortran/archive/v4.4.4.tar.gz && tar -xvzf v4.4.4.tar.gz
-RUN cd netcdf-fortran-4.4.4; \
-    CPPFLAGS=-I${PREFIXDIR}/include LDFLAGS=-L${PREFIXDIR}/lib ./configure --prefix=${PREFIXDIR}; \
-    make check; \
-    make install; \
-    rm -rf /v4.4.4.tar.gz /netcdf-fortran-4.4.4
+FROM climateimpactlab/gfortran-netcdf-notebook:latest
 
 # build conda
 
 USER $NB_USER
 
 #Do additional conda installs
-RUN conda update --yes conda
 RUN conda config --add channels conda-forge
+RUN conda update --yes conda
 RUN conda install --yes -c conda-forge \
     basemap=1.1.0 \
     beautifulsoup4=4.6.1 \

--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -176,5 +176,7 @@ RUN pip install \
 # update pip
 RUN pip install --upgrade pip
 
+WORKDIR $HOME
+
 ENTRYPOINT ["tini", "--", "/usr/bin/prepare.sh"]
 CMD ["start.sh jupyter lab"]

--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -3,12 +3,15 @@ FROM jupyter/base-notebook
 
 #install some system level packages
 USER root
+
 RUN apt-get update \
   && apt-get install -yq --no-install-recommends \
   build-essential \
+  curl \
   fonts-dejavu \
   fuse \
   gfortran \
+  g++ \
   git \
   gnupg \
   gnupg2 \
@@ -16,9 +19,12 @@ RUN apt-get update \
   keychain \
   libcurl4-openssl-dev \
   libfuse-dev \
+  liblapack-dev \
   libssl-dev \
   locate \
   lsb-release \
+  make \
+  m4 \
   nano \
   rsync \
   tzdata \
@@ -26,10 +32,63 @@ RUN apt-get update \
   vim \
   zip
 
+# build netcdf with gcc and g-fortran
+
+ENV CC=gcc
+ENV FC=gfortran
+
+# set library location
+ENV PREFIXDIR=/usr/local
+
+## get zlib
+RUN wget https://zlib.net/zlib-1.2.11.tar.gz && tar -xvzf zlib-1.2.11.tar.gz
+RUN cd zlib-1.2.11; \
+    ./configure --prefix=${PREFIXDIR}; \
+    make check; \
+    make install; \
+    rm -rf /zlib-1.2.11.tar.gz /zlib-1.2.11
+
+
+## get hdf5-1.8
+RUN wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8/hdf5-1.8.21/src/hdf5-1.8.21.tar.gz && tar -xvzf hdf5-1.8.21.tar.gz
+RUN cd hdf5-1.8.20; \
+    ./configure --with-zlib=${PREFIXDIR} --prefix=${PREFIXDIR} --enable-hl; \
+    make check; \
+    make install; \
+    rm -rf /hdf5-1.8.21.tar.gz /hdf5-1.8.21
+
+## get hdf5-1.10
+RUN wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.2/src/hdf5-1.10.2.tar.gz && tar -xvzf hdf5-1.10.2.tar.gz
+RUN cd hdf5-1.10.2; \
+    ./configure --with-zlib=${PREFIXDIR} --prefix=${PREFIXDIR} --enable-hl --enable-shared; \
+    make check; \
+    make install; \
+    rm -rf /hdf5-1.10.2.tar.gz /hdf5-1.10.2
+
+## get netcdf-c
+RUN wget https://github.com/Unidata/netcdf-c/archive/v4.6.1.tar.gz && tar -xvzf v4.6.1.tar.gz
+ENV LD_LIBRARY_PATH=${PREFIXDIR}/lib
+RUN cd netcdf-c-4.6.1; \
+    CPPFLAGS=-I${PREFIXDIR}/include LDFLAGS=-L${PREFIXDIR}/lib ./configure --prefix=${PREFIXDIR} --enable-netcdf-4 --enable-shared --enable-dap; \
+    make check; \
+    make install; \
+    rm -rf /v4.6.1.tar.gz /netcdf-c-4.6.1
+
+## get netcdf-fortran
+RUN wget https://github.com/Unidata/netcdf-fortran/archive/v4.4.4.tar.gz && tar -xvzf v4.4.4.tar.gz
+RUN cd netcdf-fortran-4.4.4; \
+    CPPFLAGS=-I${PREFIXDIR}/include LDFLAGS=-L${PREFIXDIR}/lib ./configure --prefix=${PREFIXDIR}; \
+    make check; \
+    make install; \
+    rm -rf /v4.4.4.tar.gz /netcdf-fortran-4.4.4
+
+# build conda
+
 USER $NB_USER
 
 #Do additional conda installs
 RUN conda update --yes conda
+RUN conda config --add channels conda-forge
 RUN conda install --yes -c conda-forge \
     basemap=1.1.0 \
     beautifulsoup4=4.6.1 \
@@ -193,6 +252,9 @@ RUN pip install \
   impactlab-tools==0.3.1 \
   climate-toolbox==0.1.4 \
   --no-cache-dir
+
+# update pip
+RUN pip install --upgrade pip
 
 ENTRYPOINT ["tini", "--", "/usr/bin/prepare.sh"]
 CMD ["start.sh jupyter lab"]

--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -1,4 +1,4 @@
-FROM climateimpactlab/gfortran-netcdf-notebook:latest
+FROM climateimpactlab/gfortran-netcdf-notebook:v1.0.2
 
 # build conda
 

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,89 +1,11 @@
-FROM continuumio/miniconda3:4.5.4
-
-# Dumb init
-RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64
-RUN chmod +x /usr/local/bin/dumb-init
-
-USER root
-RUN apt-get update \
-  && apt-get install -yq --no-install-recommends \
-  build-essential \
-  curl \
-  fuse \
-  gfortran \
-  g++ \
-  git \
-  gnupg \
-  gnupg2 \
-  keychain \
-  libcurl4-openssl-dev \
-  libfuse-dev \
-  liblapack-dev \
-  libssl-dev \
-  locate \
-  lsb-release \
-  make \
-  m4 \
-  nano \
-  rsync \
-  tzdata \
-  unzip \
-  vim \
-  zip
-
-# build netcdf with gcc and g-fortran
-
-ENV CC=gcc
-ENV FC=gfortran
-
-# set library location
-ENV PREFIXDIR=/usr/local
-
-## get zlib
-RUN wget https://zlib.net/zlib-1.2.11.tar.gz && tar -xvzf zlib-1.2.11.tar.gz
-RUN cd zlib-1.2.11; \
-    ./configure --prefix=${PREFIXDIR}; \
-    make check; \
-    make install; \
-    rm -rf /zlib-1.2.11.tar.gz /zlib-1.2.11
-
-
-## get hdf5-1.8
-RUN wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8/hdf5-1.8.21/src/hdf5-1.8.21.tar.gz && tar -xvzf hdf5-1.8.21.tar.gz
-RUN cd hdf5-1.8.20; \
-    ./configure --with-zlib=${PREFIXDIR} --prefix=${PREFIXDIR} --enable-hl; \
-    make check; \
-    make install; \
-    rm -rf /hdf5-1.8.21.tar.gz /hdf5-1.8.21
-
-## get hdf5-1.10
-RUN wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.2/src/hdf5-1.10.2.tar.gz && tar -xvzf hdf5-1.10.2.tar.gz
-RUN cd hdf5-1.10.2; \
-    ./configure --with-zlib=${PREFIXDIR} --prefix=${PREFIXDIR} --enable-hl --enable-shared; \
-    make check; \
-    make install; \
-    rm -rf /hdf5-1.10.2.tar.gz /hdf5-1.10.2
-
-## get netcdf-c
-RUN wget https://github.com/Unidata/netcdf-c/archive/v4.6.1.tar.gz && tar -xvzf v4.6.1.tar.gz
-ENV LD_LIBRARY_PATH=${PREFIXDIR}/lib
-RUN cd netcdf-c-4.6.1; \
-    CPPFLAGS=-I${PREFIXDIR}/include LDFLAGS=-L${PREFIXDIR}/lib ./configure --prefix=${PREFIXDIR} --enable-netcdf-4 --enable-shared --enable-dap; \
-    make check; \
-    make install; \
-    rm -rf /v4.6.1.tar.gz /netcdf-c-4.6.1
-
-## get netcdf-fortran
-RUN wget https://github.com/Unidata/netcdf-fortran/archive/v4.4.4.tar.gz && tar -xvzf v4.4.4.tar.gz
-RUN cd netcdf-fortran-4.4.4; \
-    CPPFLAGS=-I${PREFIXDIR}/include LDFLAGS=-L${PREFIXDIR}/lib ./configure --prefix=${PREFIXDIR}; \
-    make check; \
-    make install; \
-    rm -rf /v4.4.4.tar.gz /netcdf-fortran-4.4.4
+FROM climateimpactlab/miniconda3-gfortran-netcdf:latest
 
 # build conda
-RUN conda update --yes conda
+
+USER $NB_USER
+
 RUN conda config --add channels conda-forge
+RUN conda update --yes conda
 RUN conda create -n worker --yes -c conda-forge \
     python=3.6 \
     basemap=1.1.0 \

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM climateimpactlab/miniconda3-gfortran-netcdf:latest
+FROM climateimpactlab/miniconda3-gfortran-netcdf:v1.0.1
 
 # build conda
 
@@ -7,7 +7,6 @@ USER $NB_USER
 RUN conda config --add channels conda-forge
 RUN conda update --yes conda
 RUN conda create -n worker --yes -c conda-forge \
-    python=3.6 \
     basemap=1.1.0 \
     beautifulsoup4=4.6.1 \
     bokeh=0.12.15 \
@@ -47,13 +46,16 @@ RUN conda create -n worker --yes -c conda-forge \
     netcdf-fortran=4.4.4 \
     netcdf4=1.3.1 \
     nomkl=2.0 \
+    nose=1.3.7 \
     numba=0.37.0 \
     numcodecs=0.5.5 \
     numpy=1.14.2 \
     pandas=0.23.2 \
     pip=9.0.3 \
+    pyshp=1.2.12 \
     python-blosc=1.4.4 \
     python-snappy=0.5.3 \
+    python=3.6 \
     PyYAML=3.12 \
     rasterio=0.36.0 \
     scikit-image=0.14.0 \

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM climateimpactlab/miniconda3-gfortran-netcdf:v1.0.1
+FROM climateimpactlab/miniconda3-gfortran-netcdf:latest
 
 # build conda
 

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -8,17 +8,22 @@ USER root
 RUN apt-get update \
   && apt-get install -yq --no-install-recommends \
   build-essential \
+  curl \
   fuse \
   gfortran \
+  g++ \
   git \
   gnupg \
   gnupg2 \
   keychain \
   libcurl4-openssl-dev \
   libfuse-dev \
+  liblapack-dev \
   libssl-dev \
   locate \
   lsb-release \
+  make \
+  m4 \
   nano \
   rsync \
   tzdata \
@@ -26,7 +31,59 @@ RUN apt-get update \
   vim \
   zip
 
+# build netcdf with gcc and g-fortran
+
+ENV CC=gcc
+ENV FC=gfortran
+
+# set library location
+ENV PREFIXDIR=/usr/local
+
+## get zlib
+RUN wget https://zlib.net/zlib-1.2.11.tar.gz && tar -xvzf zlib-1.2.11.tar.gz
+RUN cd zlib-1.2.11; \
+    ./configure --prefix=${PREFIXDIR}; \
+    make check; \
+    make install; \
+    rm -rf /zlib-1.2.11.tar.gz /zlib-1.2.11
+
+
+## get hdf5-1.8
+RUN wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8/hdf5-1.8.21/src/hdf5-1.8.21.tar.gz && tar -xvzf hdf5-1.8.21.tar.gz
+RUN cd hdf5-1.8.20; \
+    ./configure --with-zlib=${PREFIXDIR} --prefix=${PREFIXDIR} --enable-hl; \
+    make check; \
+    make install; \
+    rm -rf /hdf5-1.8.21.tar.gz /hdf5-1.8.21
+
+## get hdf5-1.10
+RUN wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.2/src/hdf5-1.10.2.tar.gz && tar -xvzf hdf5-1.10.2.tar.gz
+RUN cd hdf5-1.10.2; \
+    ./configure --with-zlib=${PREFIXDIR} --prefix=${PREFIXDIR} --enable-hl --enable-shared; \
+    make check; \
+    make install; \
+    rm -rf /hdf5-1.10.2.tar.gz /hdf5-1.10.2
+
+## get netcdf-c
+RUN wget https://github.com/Unidata/netcdf-c/archive/v4.6.1.tar.gz && tar -xvzf v4.6.1.tar.gz
+ENV LD_LIBRARY_PATH=${PREFIXDIR}/lib
+RUN cd netcdf-c-4.6.1; \
+    CPPFLAGS=-I${PREFIXDIR}/include LDFLAGS=-L${PREFIXDIR}/lib ./configure --prefix=${PREFIXDIR} --enable-netcdf-4 --enable-shared --enable-dap; \
+    make check; \
+    make install; \
+    rm -rf /v4.6.1.tar.gz /netcdf-c-4.6.1
+
+## get netcdf-fortran
+RUN wget https://github.com/Unidata/netcdf-fortran/archive/v4.4.4.tar.gz && tar -xvzf v4.4.4.tar.gz
+RUN cd netcdf-fortran-4.4.4; \
+    CPPFLAGS=-I${PREFIXDIR}/include LDFLAGS=-L${PREFIXDIR}/lib ./configure --prefix=${PREFIXDIR}; \
+    make check; \
+    make install; \
+    rm -rf /v4.4.4.tar.gz /netcdf-fortran-4.4.4
+
+# build conda
 RUN conda update --yes conda
+RUN conda config --add channels conda-forge
 RUN conda create -n worker --yes -c conda-forge \
     python=3.6 \
     basemap=1.1.0 \
@@ -136,5 +193,8 @@ RUN /opt/conda/envs/worker/bin/pip install \
   impactlab-tools==0.3.1 \
   climate-toolbox==0.1.4 \
   --no-cache-dir
+
+# update pip
+RUN /opt/conda/envs/worker/bin/pip install --upgrade pip
 
 ENTRYPOINT ["/usr/local/bin/dumb-init", "/usr/bin/prepare.sh"]

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM climateimpactlab/miniconda3-gfortran-netcdf:latest
+FROM climateimpactlab/miniconda3-gfortran-netcdf:v1.0.2
 
 # build conda
 

--- a/worker/prepare.sh
+++ b/worker/prepare.sh
@@ -4,14 +4,14 @@ set -x
 
 if [[ -e "/opt/app/environment.yml" ]]; then
     echo "environment.yml found. Installing packages"
-    /opt/conda/bin/conda env update -f /opt/app/environment.yml
+    /opt/conda/bin/conda env update -n worker -f /opt/app/environment.yml
 else
     echo "no environment.yml"
 fi
 
 if [[ "$EXTRA_CONDA_PACKAGES" ]]; then
     echo "EXTRA_CONDA_PACKAGES environment variable found.  Installing."
-    /opt/conda/envs/worker/bin/conda install --yes $EXTRA_CONDA_PACKAGES
+    /opt/conda/bin/conda install -n worker --yes $EXTRA_CONDA_PACKAGES
 fi
 
 if [[ "$EXTRA_PIP_PACKAGES" ]]; then


### PR DESCRIPTION
## Workflow

* [x] Closes issue ClimateImpactLab/bolliger32-clawpack-image#8 and #53 
* [x] Notebook:worker pairing builds & passes local build, visual inspection & client.map tests
* [x] Passes travis tests
* [x] Image deployed on `dev` branch (see [notebook](https://hub.docker.com/r/rhodium/notebook/tags/) and [worker](https://hub.docker.com/r/rhodium/worker/tags/) dev tags)
* [x] Worker passes manual deployment test on compute.rhg
* [x] Notebook+worker passes test-hub deployment
* [x] Updates integrated into downstream images

## Summary

pulls from custom versions of jupyter/base-notebook and continuumio/miniconda3 with netcdf-fortran compiled using gfortran and gcc. intent here is to speed up downstream geoclaw build process by caching this lengthy step.