### PR TITLE
bump rhg_compute_tools to v0.1.2

### DIFF
--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -168,7 +168,7 @@ RUN sed -ri "s#Defaults\s+secure_path=\"([^\"]+)\"#Defaults secure_path=\"\1:$CO
 USER $NB_USER
 
 RUN pip install \
-  rhg_compute_tools==0.1.0 \
+  rhg_compute_tools==0.1.2 \
   impactlab-tools==0.3.1 \
   climate-toolbox==0.1.4 \
   --no-cache-dir

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -114,7 +114,7 @@ RUN mkdir /opt/app
 RUN mkdir /gcs
 
 RUN /opt/conda/envs/worker/bin/pip install \
-  rhg_compute_tools==0.1.0 \
+  rhg_compute_tools==0.1.2 \
   impactlab-tools==0.3.1 \
   climate-toolbox==0.1.4 \
   --no-cache-dir


### PR DESCRIPTION
## Workflow

* [x] Closes issue #66 
* [ ] Notebook:worker pairing builds & passes local build, visual inspection & client.map tests
* [ ] Passes travis tests
* [ ] Image deployed on `dev` branch (see [notebook](https://hub.docker.com/r/rhodium/notebook/tags/) and [worker](https://hub.docker.com/r/rhodium/worker/tags/) dev tags)
* [ ] Worker passes manual deployment test on compute.rhg
* [ ] Notebook+worker passes test-hub deployment
* [ ] Updates integrated into downstream images

## Summary

Updates rhg_compute_tools to v0.1.2