### PR TITLE
build dask-kubernetes from master

### DIFF
--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -104,7 +104,7 @@ RUN conda install --quiet --yes \
 RUN pip install \
   bumpversion==0.5.3 \
   coverage==4.5.1 \
-  dask-kubernetes==0.5.0 \
+  git+git://github.com/dask/dask-kubernetes.git@295f06428119bc8e674a2e6a59cd97000fae69e8 \
   flake8==3.5.0 \
   google-cloud-storage==1.12.0 \
   kubernetes==6.0.0 \

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -88,7 +88,7 @@ RUN export GCSFUSE_REPO=gcsfuse-xenial \
   && alias googlefuse=/usr/bin/gcsfuse
 
 RUN /opt/conda/envs/worker/bin/pip install \
-    dask-kubernetes==0.5.0 \
+    git+git://github.com/dask/dask-kubernetes.git@295f06428119bc8e674a2e6a59cd97000fae69e8 \
     google-cloud-storage==1.12.0 \
     pyasn1-modules==0.2.2 \
     pyasn1==0.4.3 \


### PR DESCRIPTION
## Workflow

* [x] Closes issue #72 
* [ ] Notebook:worker pairing builds & passes local build, visual inspection & client.map tests
* [x] Passes travis tests
* [ ] Image deployed on `dev` branch (see [notebook](https://hub.docker.com/r/rhodium/notebook/tags/) and [worker](https://hub.docker.com/r/rhodium/worker/tags/) dev tags)
* [ ] Worker passes manual deployment test on compute.rhg
* [x] Notebook+worker passes test-hub deployment
* [x] Updates integrated into downstream images

## Summary

Pulls dask-kubernetes from master (pinned to commit [295f064](https://github.com/dask/dask-kubernetes/commit/295f06428119bc8e674a2e6a59cd97000fae69e8)). This is an attempt to fix the autoscaling & scale down issue.