### PR TITLE
update packages to allow for interactive mpl

### DIFF
--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -35,14 +35,15 @@ RUN conda install --yes -c conda-forge \
     gitpython=2.1.11 \
     holoviews=1.10.7 \
     ipdb=0.11 \
+    ipympl=0.2.1 \
     ipywidgets=7.4.2 \
     jedi=0.12.0 \
     jupyter=1.0.0 \
     jupyterhub=0.9.4 \
-    jupyterlab=0.35.2 \
+    jupyterlab=0.35.4 \
     lz4-c=1.8.1.2 \
     lz4=1.1.0 \
-    matplotlib=2.2.2 \
+    matplotlib=3.0.2 \
     nb_conda_kernels=2.1.1 \
     nbserverproxy=0.8.3 \
     ncurses=6.1 \
@@ -50,11 +51,11 @@ RUN conda install --yes -c conda-forge \
     netcdf4=1.3.1 \
     nomkl=2.0 \
     nose=1.3.7 \
-    numba=0.37.0 \
+    numba=0.40.0 \
     numcodecs=0.5.5 \
-    numpy=1.14.2 \
+    numpy=1.15.4 \
     pandas=0.23.4 \
-    pip=9.0.3 \
+    pip=18.1 \
     pyshp=1.2.12 \
     python-blosc=1.4.4 \
     python-snappy=0.5.3 \
@@ -119,14 +120,18 @@ RUN pip install \
   wheel==0.31.1 \
   xesmf==0.1.1 \
   xlrd==1.1.0 \
+  rhg_compute_tools==0.1.5 \
+  impactlab-tools==0.3.1 \
+  climate-toolbox==0.1.4 \
   --no-cache-dir
 
 RUN jupyter labextension install \
-  @jupyter-widgets/jupyterlab-manager@0.38 \
+  @jupyter-widgets/jupyterlab-manager@0.38.1 \
   @jupyterlab/hub-extension@0.12.0 \
   jupyterlab_bokeh@0.6.3 \
-  @pyviz/jupyterlab_pyviz \
-  dask-labextension
+  @pyviz/jupyterlab_pyviz@0.6.3 \
+  dask-labextension@0.2.0 \
+  jupyter-matplotlib@0.3.0
 
 RUN jupyter serverextension enable --py nbserverproxy --sys-prefix
 
@@ -168,15 +173,6 @@ RUN mkdir /opt/app
 RUN echo "$NB_USER ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/notebook
 RUN sed -ri "s#Defaults\s+secure_path=\"([^\"]+)\"#Defaults secure_path=\"\1:$CONDA_DIR/bin\"#" /etc/sudoers
 USER $NB_USER
-
-RUN pip install \
-  rhg_compute_tools==0.1.5 \
-  impactlab-tools==0.3.1 \
-  climate-toolbox==0.1.4 \
-  --no-cache-dir
-
-# update pip
-RUN pip install --upgrade pip
 
 WORKDIR $HOME
 

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -40,7 +40,7 @@ RUN conda create -n worker --yes -c conda-forge \
     jupyter=1.0.0 \
     lz4-c=1.8.1.2 \
     lz4=1.1.0 \
-    matplotlib=2.2.2 \
+    matplotlib=3.0.2 \
     nb_conda_kernels=2.1.1 \
     nbserverproxy=0.8.3 \
     ncurses=6.1 \
@@ -48,11 +48,11 @@ RUN conda create -n worker --yes -c conda-forge \
     netcdf4=1.3.1 \
     nomkl=2.0 \
     nose=1.3.7 \
-    numba=0.37.0 \
+    numba=0.40.0 \
     numcodecs=0.5.5 \
-    numpy=1.14.2 \
+    numpy=1.15.4 \
     pandas=0.23.4 \
-    pip=9.0.3 \
+    pip=18.1 \
     pyshp=1.2.12 \
     python-blosc=1.4.4 \
     python-snappy=0.5.3 \
@@ -94,6 +94,9 @@ RUN /opt/conda/envs/worker/bin/pip install \
     pyasn1==0.4.3 \
     wget==3.2 \
     xesmf==0.1.1 \
+    rhg_compute_tools==0.1.0 \
+    impactlab-tools==0.3.1 \
+    climate-toolbox==0.1.4 \
     --no-cache-dir
 
 # clean up
@@ -113,14 +116,5 @@ COPY add_service_creds.py /usr/bin/add_service_creds.py
 RUN chmod +x /usr/bin/prepare.sh
 RUN mkdir /opt/app
 RUN mkdir /gcs
-
-RUN /opt/conda/envs/worker/bin/pip install \
-  rhg_compute_tools==0.1.0 \
-  impactlab-tools==0.3.1 \
-  climate-toolbox==0.1.4 \
-  --no-cache-dir
-
-# update pip
-RUN /opt/conda/envs/worker/bin/pip install --upgrade pip
 
 ENTRYPOINT ["/usr/local/bin/dumb-init", "/usr/bin/prepare.sh"]


### PR DESCRIPTION
## Workflow

* [x] Closes issue #77 
* [x] Notebook:worker pairing builds & passes local build, visual inspection & client.map tests
* [ ] Passes travis tests
* [ ] Image deployed on `dev` branch (see [notebook](https://hub.docker.com/r/rhodium/notebook/tags/) and [worker](https://hub.docker.com/r/rhodium/worker/tags/) dev tags)
* [ ] Worker passes manual deployment test on compute.rhg
* [ ] Notebook+worker passes test-hub deployment
* [ ] Updates integrated into downstream images

## Summary

Updated conda packages with the original intent to allow the `%matplotlib widget` magic to work, enabling interactive mpl plots. In doing so, ended up updating a few other packages (some of which were necessary to enable this). See list below.

Also, conda installed latest pip, rather than conda installing earlier pip and then pip-installing latest pip. If that was there for a reason, just let me know and I can undo that change.

### Features

* install ipympl
* update:
    - jupyterlab
    - matplotlib
    - numba
    - numpy
    - jupyterlab-manager
* pin some labextensions
