### PR TITLE
WIP: can set auth with env var

### DIFF
--- a/worker/prepare.sh
+++ b/worker/prepare.sh
@@ -45,8 +45,8 @@ if [[ "$SQL_TOKEN" ]]; then
     fi;
 fi
 
-if [[ "$GCLOUD_DEFAULT_TOKEN_FILE" ]]; then
-    gcloud auth activate-service-account --key-file $GCLOUD_DEFAULT_TOKEN_FILE;
+if [[ "$GOOGLE_APPLICATION_CREDENTIALS" ]]; then
+    gcloud auth activate-service-account --key-file $GOOGLE_APPLICATION_CREDENTIALS;
 fi
 
 # Run extra commands


### PR DESCRIPTION
Once RhodiumGroup/rhg_compute_tools#41 is merged, we can point to this new env var and then remove the assigning of `$GCLOUD_DEFAULT_TOKEN_FILE` in `rhg_compute_tools.kubernetes.get_cluster`.



## Workflow

* [ ] Closes issue #
* [ ] Notebook:worker pairing builds & passes local build, visual inspection & client.map tests
* [ ] Passes travis tests
* [ ] Image deployed on `dev` branch (see [notebook](https://hub.docker.com/r/rhodium/notebook/tags/) and [worker](https://hub.docker.com/r/rhodium/worker/tags/) dev tags)
* [ ] Worker passes manual deployment test on compute.rhg
* [ ] Notebook+worker passes test-hub deployment
* [ ] Updates integrated into downstream images

## Summary

Provide an overview of your PR here

### Features

* components should be
* enumerated in bullets
