### PR TITLE
Handle no creds in service-account-credentials

### DIFF
--- a/notebook/prepare.sh
+++ b/notebook/prepare.sh
@@ -18,11 +18,14 @@ sudo cp /home/jovyan/service-account-credentials/*.json /opt/gcsfuse_tokens/
 
 for f in /home/jovyan/service-account-credentials/*.json;
 do
-    bucket=$(basename ${f/.json/});
-    if ! grep -q "/gcs/${bucket}" /proc/mounts; then
-        echo "Mounting $bucket to /gcs/${bucket}";
-        mkdir -p "/gcs/$bucket";
-        /usr/bin/gcsfuse --key-file="$f" "$bucket" "/gcs/${bucket}";
+    # check to make sure we're matching a file, not literally '../*.json'
+    if [[ -f "$f" ]]; then
+        bucket=$(basename ${f/.json/});
+        if ! grep -q "/gcs/${bucket}" /proc/mounts; then
+            echo "Mounting $bucket to /gcs/${bucket}";
+            mkdir -p "/gcs/$bucket";
+            /usr/bin/gcsfuse --key-file="$f" "$bucket" "/gcs/${bucket}";
+        fi;
     fi;
 done
 


### PR DESCRIPTION
Right now if there are no credential files in ~/service-account-credentials, a single directory, `'*'`, is created in `/gcs`. The behavior should be to take no action.

## Workflow

* [ ] Closes issue #
* [ ] Notebook:worker pairing builds & passes local build, visual inspection & client.map tests
* [ ] Passes travis tests
* [ ] Image deployed on `dev` branch (see [notebook](https://hub.docker.com/r/rhodium/notebook/tags/) and [worker](https://hub.docker.com/r/rhodium/worker/tags/) dev tags)
* [ ] Worker passes manual deployment test on compute.rhg
* [ ] Notebook+worker passes test-hub deployment
* [ ] Updates integrated into downstream images

## Summary

Provide an overview of your PR here

### Features

* components should be
* enumerated in bullets
