### PR TITLE
pin intake-esm

### DIFF
--- a/base_environment.yml
+++ b/base_environment.yml
@@ -104,7 +104,7 @@ dependencies:
     - climate-toolbox==0.1.5
     - impactlab-tools==0.4.0
     - parameterize-jobs==0.1.1
-    - git+https://github.com/rhodiumgroup/rhg_compute_tools.git@allow-remote-scheduler#egg=rhg_compute_tools
+    - rhg_compute_tools==0.2.1
     - git+https://github.com/NCAR/intake-esm.git@v2020.3.16.2#egg=intake_esm
 # need to install from master until 0.10.1
 # due to handling of remote scheduler

--- a/base_environment.yml
+++ b/base_environment.yml
@@ -105,8 +105,8 @@ dependencies:
     - impactlab-tools==0.4.0
     - parameterize-jobs==0.1.1
     - git+https://github.com/rhodiumgroup/rhg_compute_tools.git@allow-remote-scheduler#egg=rhg_compute_tools
-    - git+https://github.com/NCAR/intake-esm.git#egg=intake_esm
+    - git+https://github.com/NCAR/intake-esm.git@v2020.3.16.2#egg=intake_esm
 # need to install from master until 0.10.1
 # due to handling of remote scheduler
 # (we also should at some point switch to dask-gateway instead of dask-kubernetes)
-    - git+https://github.com/dask/dask-kubernetes.git#egg=dask_kubernetes
+    - dask_kubernetes==0.10.1


### PR DESCRIPTION
## Workflow

* [x] Closes issue #120 
* [ ] Notebook:worker pairing builds & passes local build, visual inspection & client.map tests
* [x] Passes travis tests
* [ ] Image deployed on `dev` branch (see [notebook](https://hub.docker.com/r/rhodium/notebook/tags/) and [worker](https://hub.docker.com/r/rhodium/worker/tags/) dev tags)
* [ ] Worker passes manual deployment test on compute.rhg
* [ ] Notebook+worker passes test-hub deployment
* [ ] Updates integrated into downstream images

## Summary

I *think* the issue identified in #120 where we are installing latest versions of xarray through pypi is due to intake-esm's requirement of xarray>=0.15.1. We'll see if this does the trick.

### Features

* components should be
* enumerated in bullets
