### PR TITLE
Update rhg_compute_tools to 0.2.2

### DIFF
--- a/base_environment.yml
+++ b/base_environment.yml
@@ -104,7 +104,7 @@ dependencies:
     - climate-toolbox==0.1.5
     - impactlab-tools==0.4.0
     - parameterize-jobs==0.1.1
-    - rhg_compute_tools==0.2.1
+    - rhg_compute_tools==0.2.2
     - git+https://github.com/NCAR/intake-esm.git@v2020.3.16.2#egg=intake_esm
 # need to install from master until 0.10.1
 # due to handling of remote scheduler


### PR DESCRIPTION
Bump version of rhg_compute_tools to [v0.2.2](https://github.com/RhodiumGroup/rhg_compute_tools/releases/tag/v0.2.2) in base_environment.yml