### PR TITLE
do not simply update worker template - always overwrite

### DIFF
--- a/notebook/prepare.sh
+++ b/notebook/prepare.sh
@@ -5,7 +5,12 @@ set -x
 echo "Copy Dask configuration files from pre-load directory into home/.config"
 mkdir -p /home/jovyan/.config/dask
 cp --update -r -v /pre-home/config.yaml /home/jovyan/.config/dask/
+
+# should probably pick one of these!!! The second is new, but is implied by the
+# cp /pre-home below, and we actually only read the version in ~ in rhg_compute_tools.
 cp -r -v /pre-home/worker-template.yml /home/jovyan/.config/dask/
+cp -r -v /pre-home/worker-template.yml /home/jovyan/
+
 sudo rm /pre-home/config.yaml
 
 echo "Copy files from pre-load directory into home"

--- a/notebook/prepare.sh
+++ b/notebook/prepare.sh
@@ -5,7 +5,7 @@ set -x
 echo "Copy Dask configuration files from pre-load directory into home/.config"
 mkdir -p /home/jovyan/.config/dask
 cp --update -r -v /pre-home/config.yaml /home/jovyan/.config/dask/
-cp --update -r -v /pre-home/worker-template.yml /home/jovyan/.config/dask/
+cp -r -v /pre-home/worker-template.yml /home/jovyan/.config/dask/
 sudo rm /pre-home/config.yaml
 
 echo "Copy files from pre-load directory into home"


### PR DESCRIPTION
## Workflow

* [x] Closes issue #128 
* [x] Passes travis tests

## Summary

Always copy `worker-template.yml` rather than updating. Fixes the problem of the dask worker getting "stuck" on the most recently updated verison of worker-template.yml.

Couple outstanding issues:
* We previously copied worker-template.yml and config.yml to both ~ and ~/.config/dask. This is weird and stupid. We should probably just stick it in ~/.config/dask, but we'd need to update rhg_compute_tools to also pull from that location, and would also need to make these changes bi-directionally backwards compatible to make sure we don't inadvertently break things across all the images floating around. For now, I just make this explicit and include a comment whining about it. AFAICT, ~/.config/dask/worker-template.yml is never used, and neither is ~/config.yml, but we should check.
* This of course doesn't fix the fact that this issue still exists on older images, so while images with this patch will always get the right worker, this updated default will stick around when switching back to older images. This will continue to be a problem until we upgrade `rhodium:stable` and `pyTC:stable`
