### PR TITLE
Update notebook_environment.yml

### DIFF
--- a/notebook/notebook_environment.yml
+++ b/notebook/notebook_environment.yml
@@ -11,6 +11,7 @@ dependencies:
   - ipympl=0.3.3=py_0
   - jupyterlab_code_formatter=0.7.0=py_0
   - nano=2.9.8=hb256ff8_1000
+  - nbdime=2.0.0
   - nb_conda_kernels=2.2.2=py37_0
   - nose=1.3.7=py37_1003
   - octave_kernel=0.31.0=py_0


### PR DESCRIPTION
## Workflow

* [ ] Closes issue #
* [ ] Notebook:worker pairing builds & passes local build, visual inspection & client.map tests
* [ ] Passes travis tests
* [ ] Image deployed on `dev` branch (see [notebook](https://hub.docker.com/r/rhodium/notebook/tags/) and [worker](https://hub.docker.com/r/rhodium/worker/tags/) dev tags)
* [ ] Worker passes manual deployment test on compute.rhg
* [ ] Notebook+worker passes test-hub deployment
* [ ] Updates integrated into downstream images

## Summary

Installs the [nbdime](https://github.com/jupyter/nbdime) package & plugin for computing and viewing jupyter notebook diffs in an interactive widget.