### PR TITLE
upgrade xarray & intake-esm

### DIFF
--- a/base_environment.yml
+++ b/base_environment.yml
@@ -44,6 +44,7 @@ dependencies:
   - holoviews=1.12.7=py_0
   - h5netcdf=0.7.4=py_0
   - icu=64.2=he1b5a44_1
+  - intake-esm=2020.6.11
   - iris=2.2.0=py37_1003
   - jedi=0.15.1=py37_0
 # need server proxy on workers if using remote scheduler
@@ -105,7 +106,6 @@ dependencies:
     - impactlab-tools==0.4.0
     - parameterize-jobs==0.1.1
     - rhg_compute_tools==0.2.2
-    - intake-esm==2020.6.11
 # need to install from master until 0.10.1
 # due to handling of remote scheduler
 # (we also should at some point switch to dask-gateway instead of dask-kubernetes)

--- a/base_environment.yml
+++ b/base_environment.yml
@@ -88,7 +88,7 @@ dependencies:
   - tini=0.18.0=h14c3975_1001
   - unzip=6.0=h516909a_0
   - uritemplate=3.0.0=py_1
-  - xarray=0.14.1=py_0
+  - xarray=0.16.0=py_0
   - xesmf=0.2.1=py_0
   - xgcm=0.2.0=py_0
   - xhistogram=0.1.1=py_0
@@ -105,7 +105,7 @@ dependencies:
     - impactlab-tools==0.4.0
     - parameterize-jobs==0.1.1
     - rhg_compute_tools==0.2.1
-    - git+https://github.com/NCAR/intake-esm.git@v2020.3.16.2#egg=intake_esm
+    - intake-esm
 # need to install from master until 0.10.1
 # due to handling of remote scheduler
 # (we also should at some point switch to dask-gateway instead of dask-kubernetes)


### PR DESCRIPTION
## Workflow

* [ ] Closes issue #
* [ ] Notebook:worker pairing builds & passes local build, visual inspection & client.map tests
* [ ] Passes travis tests
* [ ] Image deployed on `dev` branch (see [notebook](https://hub.docker.com/r/rhodium/notebook/tags/) and [worker](https://hub.docker.com/r/rhodium/worker/tags/) dev tags)
* [ ] Worker passes manual deployment test on compute.rhg
* [ ] Notebook+worker passes test-hub deployment
* [ ] Updates integrated into downstream images

## Summary

Updates xarray and intake-esm to their latest versions. Required to work with Pangeo CMIP datastore.

