### PR TITLE
Pare down PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,18 +1,12 @@
 ## Workflow
 
 * [ ] Closes issue #
-* [ ] Notebook:worker pairing builds & passes local build, visual inspection & client.map tests
 * [ ] Passes travis tests
-* [ ] Image deployed on `dev` branch (see [notebook](https://hub.docker.com/r/rhodium/notebook/tags/) and [worker](https://hub.docker.com/r/rhodium/worker/tags/) dev tags)
-* [ ] Worker passes manual deployment test on compute.rhg
-* [ ] Notebook+worker passes test-hub deployment
-* [ ] Updates integrated into downstream images
 
 ## Summary
 
-Provide an overview of your PR here
-
-### Features
+Provide an overview of your PR here, with a quick description
+up here at the top, and important items in a list:
 
 * components should be
 * enumerated in bullets


### PR DESCRIPTION
Now that we can reliably deploy multiple images, there's less of a burden on any one PR. let's lower the barrier to contributions with a less confusing PR template!

**Note: all this PR does is modify the PR template**